### PR TITLE
Añadir funcionalidad de detalle de ganancia por proceso

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import InventoryPage from './pages/InventoryPage';
 import FinancialPage from './pages/FinancialPage';
 import ReportsPage from './pages/ReportsPage';
 import SettingsPage from './pages/SettingsPage';
+import ProcessProfitPage from './pages/ProcessProfitPage';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/inventory" element={<InventoryPage />} />
         <Route path="/financial" element={<FinancialPage />} />
+        <Route path="/process-profit" element={<ProcessProfitPage />} />
         <Route path="/reports" element={<ReportsPage />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Route>

--- a/client/src/components/DateRangePicker.js
+++ b/client/src/components/DateRangePicker.js
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { CalendarIcon } from '@heroicons/react/24/outline';
+
+const DateRangePicker = ({ startDate, endDate, onChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+  
+  const handleStartDateChange = (e) => {
+    const newStartDate = new Date(e.target.value);
+    onChange(newStartDate, endDate);
+  };
+  
+  const handleEndDateChange = (e) => {
+    const newEndDate = new Date(e.target.value);
+    onChange(startDate, newEndDate);
+  };
+  
+  const formatDateForDisplay = (date) => {
+    return format(date, 'dd MMM yyyy', { locale: es });
+  };
+  
+  const formatDateForInput = (date) => {
+    return format(date, 'yyyy-MM-dd');
+  };
+  
+  return (
+    <div className="relative">
+      <button
+        onClick={handleToggle}
+        className="flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-coffee-500"
+      >
+        <CalendarIcon className="h-5 w-5 mr-2 text-gray-400" />
+        <span>
+          {formatDateForDisplay(startDate)} - {formatDateForDisplay(endDate)}
+        </span>
+      </button>
+      
+      {isOpen && (
+        <div className="absolute right-0 mt-2 p-4 bg-white rounded-md shadow-lg z-10 border border-gray-200">
+          <div className="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
+            <div>
+              <label htmlFor="start-date" className="block text-sm font-medium text-gray-700 mb-1">
+                Fecha inicial
+              </label>
+              <input
+                type="date"
+                id="start-date"
+                name="start-date"
+                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-coffee-500 focus:border-coffee-500 sm:text-sm"
+                value={formatDateForInput(startDate)}
+                onChange={handleStartDateChange}
+                max={formatDateForInput(endDate)}
+              />
+            </div>
+            
+            <div>
+              <label htmlFor="end-date" className="block text-sm font-medium text-gray-700 mb-1">
+                Fecha final
+              </label>
+              <input
+                type="date"
+                id="end-date"
+                name="end-date"
+                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-coffee-500 focus:border-coffee-500 sm:text-sm"
+                value={formatDateForInput(endDate)}
+                onChange={handleEndDateChange}
+                min={formatDateForInput(startDate)}
+              />
+            </div>
+          </div>
+          
+          <div className="mt-4 flex justify-end">
+            <button
+              type="button"
+              className="px-4 py-2 bg-coffee-600 text-white rounded-md text-sm font-medium hover:bg-coffee-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-coffee-500"
+              onClick={handleToggle}
+            >
+              Aplicar
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DateRangePicker;

--- a/client/src/components/LoadingSpinner.js
+++ b/client/src/components/LoadingSpinner.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const LoadingSpinner = ({ size = 'md' }) => {
+  // Determinar tamaño basado en prop
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-6 w-6',
+    lg: 'h-8 w-8',
+    xl: 'h-12 w-12'
+  };
+  
+  const spinnerSize = sizeClasses[size] || sizeClasses.md;
+  
+  return (
+    <div className="flex items-center justify-center">
+      <div className={`${spinnerSize} animate-spin rounded-full border-2 border-coffee-200 border-t-coffee-600`} role="status">
+        <span className="sr-only">Cargando...</span>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -8,7 +8,8 @@ import {
   Cog6ToothIcon,
   ArrowLeftOnRectangleIcon,
   XMarkIcon,
-  Bars3Icon
+  Bars3Icon,
+  CalculatorIcon
 } from '@heroicons/react/24/outline';
 
 const Sidebar = () => {
@@ -20,6 +21,7 @@ const Sidebar = () => {
     { name: 'Dashboard', path: '/', icon: HomeIcon },
     { name: 'Inventario', path: '/inventory', icon: CubeIcon },
     { name: 'Finanzas', path: '/financial', icon: BanknotesIcon },
+    { name: 'Ganancia por Proceso', path: '/process-profit', icon: CalculatorIcon },
     { name: 'Reportes', path: '/reports', icon: ChartBarIcon },
     { name: 'Configuración', path: '/settings', icon: Cog6ToothIcon },
   ];

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
+import { Link } from 'react-router-dom';
 import { 
   CubeIcon, 
   BanknotesIcon, 
@@ -8,7 +9,8 @@ import {
   ScaleIcon,
   ShoppingCartIcon,
   ClockIcon,
-  CalculatorIcon
+  CalculatorIcon,
+  ArrowTopRightOnSquareIcon
 } from '@heroicons/react/24/outline';
 
 import StatCard from '../components/StatCard';
@@ -141,13 +143,20 @@ const Dashboard = () => {
 
       {/* Tarjeta para ganancia real */}
       <div className="mb-6">
-        <StatCard 
-          title="Ganancia Real (Por Proceso)"
-          value={summary && summary.financiero.ganancia_real ? formatCurrency(summary.financiero.ganancia_real) : "S/. 0.00"}
-          icon={CalculatorIcon}
-          loading={loading}
-          description="Calculada en base al proceso de transformación del café"
-        />
+        <Link to="/process-profit" className="block">
+          <div className="relative">
+            <StatCard 
+              title="Ganancia Real (Por Proceso)"
+              value={summary && summary.financiero.ganancia_real ? formatCurrency(summary.financiero.ganancia_real) : "S/. 0.00"}
+              icon={CalculatorIcon}
+              loading={loading}
+              description="Calculada en base al proceso de transformación del café"
+            />
+            <div className="absolute top-3 right-3 text-coffee-600 hover:text-coffee-800">
+              <ArrowTopRightOnSquareIcon className="h-5 w-5" />
+            </div>
+          </div>
+        </Link>
       </div>
 
       {/* Tarjetas para montos de compras */}

--- a/client/src/pages/ProcessProfitPage.js
+++ b/client/src/pages/ProcessProfitPage.js
@@ -1,0 +1,323 @@
+import React, { useState, useEffect } from 'react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { 
+  ArrowTrendingUpIcon, 
+  CalendarIcon,
+  CurrencyDollarIcon,
+  ReceiptPercentIcon,
+  ArrowTopRightOnSquareIcon,
+  ArrowsRightLeftIcon,
+} from '@heroicons/react/24/outline';
+
+import DateRangePicker from '../components/DateRangePicker';
+import StatCard from '../components/StatCard';
+import apiService from '../services/apiService';
+import LoadingSpinner from '../components/LoadingSpinner';
+
+const ProcessProfitPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [processData, setProcessData] = useState(null);
+  const [startDate, setStartDate] = useState(() => {
+    const date = new Date();
+    date.setMonth(date.getMonth() - 1);
+    return date;
+  });
+  const [endDate, setEndDate] = useState(new Date());
+  
+  // Cargar datos de ganancias por proceso
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        
+        const data = await apiService.getProcessProfit(startDate, endDate);
+        setProcessData(data);
+        
+        setLoading(false);
+      } catch (error) {
+        console.error('Error al cargar datos de ganancias por proceso:', error);
+        setLoading(false);
+      }
+    };
+    
+    fetchData();
+  }, [startDate, endDate]);
+  
+  // Función para formatear fecha
+  const formatDate = (dateStr) => {
+    if (!dateStr) return 'Fecha desconocida';
+    const date = new Date(dateStr);
+    return format(date, 'dd MMM yyyy', { locale: es });
+  };
+  
+  // Función para formatear moneda
+  const formatCurrency = (value) => {
+    return `S/. ${parseFloat(value).toFixed(2)}`;
+  };
+  
+  // Función para formatear peso
+  const formatWeight = (value) => {
+    return `${parseFloat(value).toFixed(1)} kg`;
+  };
+  
+  // Manejar cambio de rango de fechas
+  const handleDateRangeChange = (start, end) => {
+    setStartDate(start);
+    setEndDate(end);
+  };
+  
+  return (
+    <div className="py-6">
+      <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Ganancia por Proceso</h1>
+          <p className="text-sm text-gray-500">Análisis detallado de la ganancia real por cada proceso de café</p>
+        </div>
+        
+        <div className="mt-4 md:mt-0">
+          <DateRangePicker 
+            startDate={startDate}
+            endDate={endDate}
+            onChange={handleDateRangeChange}
+          />
+        </div>
+      </div>
+      
+      {/* Cards con el resumen */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <LoadingSpinner size="lg" />
+        </div>
+      ) : (
+        <>
+          {processData && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+              <StatCard
+                title="Total Procesos"
+                value={processData.resumen.total_procesos}
+                icon={ArrowsRightLeftIcon}
+                loading={loading}
+              />
+              
+              <StatCard
+                title="Costo de Compras"
+                value={formatCurrency(processData.resumen.total_costo)}
+                icon={CurrencyDollarIcon}
+                loading={loading}
+              />
+              
+              <StatCard
+                title="Ingresos por Ventas"
+                value={formatCurrency(processData.resumen.total_ingresos)}
+                icon={ReceiptPercentIcon}
+                loading={loading}
+              />
+              
+              <StatCard
+                title="Ganancia Real"
+                value={formatCurrency(processData.resumen.total_ganancia)}
+                icon={ArrowTrendingUpIcon}
+                change={processData.resumen.total_ingresos > 0 
+                  ? `${((processData.resumen.total_ganancia / processData.resumen.total_ingresos) * 100).toFixed(1)}%` 
+                  : "0%"}
+                changeType={processData.resumen.total_ganancia > 0 ? 'up' : 'down'}
+                loading={loading}
+              />
+            </div>
+          )}
+          
+          {/* Tabla de detalle de procesos */}
+          <div className="card overflow-hidden">
+            <h2 className="text-xl font-semibold mb-4">Detalle por Proceso</h2>
+            
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Proceso
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Fecha
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Tipo de Café
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Cantidad
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Costo
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Ingresos
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Ganancia
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      % Ganancia
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {processData && processData.procesos.map((proceso, index) => (
+                    <tr key={index} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">{proceso.proceso_id}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{formatDate(proceso.fecha_proceso)}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{proceso.tipo_cafe}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{formatWeight(proceso.cantidad_entrada)}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{formatCurrency(proceso.costo_compra)}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm text-gray-500">{formatCurrency(proceso.ingresos_ventas)}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className={`text-sm font-medium ${proceso.ganancia >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          {formatCurrency(proceso.ganancia)}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className={`text-sm font-medium ${proceso.ganancia >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          {proceso.ingresos_ventas > 0 
+                            ? `${((proceso.ganancia / proceso.ingresos_ventas) * 100).toFixed(1)}%` 
+                            : "-"}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  
+                  {(!processData || processData.procesos.length === 0) && (
+                    <tr>
+                      <td colSpan="8" className="px-6 py-4 text-center text-sm text-gray-500">
+                        No se encontraron datos para el período seleccionado
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          
+          {/* Sección para mostrar el detalle de ventas por proceso */}
+          {processData && processData.procesos.length > 0 && (
+            <div className="mt-8 grid grid-cols-1 gap-6">
+              {processData.procesos.map((proceso, index) => (
+                <div key={`detail-${index}`} className="card">
+                  <h3 className="text-lg font-semibold mb-3">
+                    Detalle del Proceso: {proceso.proceso_id}
+                  </h3>
+                  
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                    <div>
+                      <h4 className="text-md font-medium mb-2">Información de Compra</h4>
+                      {proceso.detalles.compra ? (
+                        <div className="bg-gray-50 p-4 rounded-lg">
+                          <p className="text-sm mb-1"><span className="font-medium">Fecha:</span> {formatDate(proceso.detalles.compra.fecha)}</p>
+                          <p className="text-sm mb-1"><span className="font-medium">Tipo de café:</span> {proceso.detalles.compra.tipo_cafe}</p>
+                          <p className="text-sm mb-1"><span className="font-medium">Cantidad:</span> {formatWeight(proceso.detalles.compra.cantidad)}</p>
+                          <p className="text-sm mb-1"><span className="font-medium">Precio/kg:</span> {formatCurrency(proceso.detalles.compra.precio_kg)}</p>
+                          <p className="text-sm mb-1"><span className="font-medium">Total compra:</span> {formatCurrency(proceso.detalles.compra.total)}</p>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-500">No hay información disponible</p>
+                      )}
+                    </div>
+                    
+                    <div>
+                      <h4 className="text-md font-medium mb-2">Información de Almacén</h4>
+                      {proceso.detalles.almacen && proceso.detalles.almacen.length > 0 ? (
+                        <div className="bg-gray-50 p-4 rounded-lg">
+                          {proceso.detalles.almacen.map((item, idx) => (
+                            <div key={`almacen-${idx}`} className={idx > 0 ? 'mt-3 pt-3 border-t border-gray-200' : ''}>
+                              <p className="text-sm mb-1"><span className="font-medium">ID Almacén:</span> {item.almacen_id}</p>
+                              <p className="text-sm mb-1"><span className="font-medium">Fecha:</span> {formatDate(item.fecha)}</p>
+                              <p className="text-sm mb-1"><span className="font-medium">Tipo de café:</span> {item.tipo_cafe}</p>
+                              <p className="text-sm mb-1"><span className="font-medium">Cantidad:</span> {formatWeight(item.cantidad)}</p>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-500">No hay información disponible</p>
+                      )}
+                    </div>
+                  </div>
+                  
+                  <div>
+                    <h4 className="text-md font-medium mb-2">Ventas Relacionadas</h4>
+                    {proceso.ventas && proceso.ventas.length > 0 ? (
+                      <div className="overflow-x-auto">
+                        <table className="min-w-full divide-y divide-gray-200">
+                          <thead className="bg-gray-50">
+                            <tr>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Fecha
+                              </th>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Cliente
+                              </th>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Tipo de Café
+                              </th>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Cantidad
+                              </th>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Precio/kg
+                              </th>
+                              <th scope="col" className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                Total
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody className="bg-white divide-y divide-gray-200">
+                            {proceso.ventas.map((venta, vidx) => (
+                              <tr key={`venta-${vidx}`}>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
+                                  {formatDate(venta.fecha)}
+                                </td>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
+                                  {venta.cliente}
+                                </td>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
+                                  {venta.tipo_cafe}
+                                </td>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
+                                  {formatWeight(venta.cantidad)}
+                                </td>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
+                                  {formatCurrency(venta.precio_kg)}
+                                </td>
+                                <td className="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900">
+                                  {formatCurrency(venta.total)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-gray-500">No hay ventas registradas</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ProcessProfitPage;

--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -50,6 +50,16 @@ export const apiService = {
     return response.data;
   },
   
+  // Obtener datos detallados de ganancia por proceso
+  async getProcessProfit(startDate, endDate) {
+    const params = {};
+    if (startDate) params.start_date = formatDate(startDate);
+    if (endDate) params.end_date = formatDate(endDate);
+    
+    const response = await apiClient.get('/proceso-ganancia', { params });
+    return response.data;
+  },
+  
   // Obtener datos crudos de cada colección
   async getRawData(collection) {
     if (!['compras', 'ventas', 'gastos', 'proceso', 'almacen'].includes(collection)) {

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -8,7 +8,8 @@ from datetime import datetime, timedelta
 
 from server.sheets_service import (
     get_compras_data, get_ventas_data, get_gastos_data, get_proceso_data, get_almacen_data,
-    calculate_daily_summary, get_daily_summaries, get_coffee_types_summary
+    calculate_daily_summary, get_daily_summaries, get_coffee_types_summary,
+    get_detailed_profit_by_process
 )
 
 # Configurar logging
@@ -107,6 +108,41 @@ def coffee_types():
         return jsonify({
             'error': str(e),
             'message': 'Error al obtener tipos de café'
+        }), 500
+
+@api_bp.route('/proceso-ganancia', methods=['GET'])
+def proceso_ganancia():
+    """
+    Obtener el detalle de ganancias por proceso individual
+    
+    Query parameters:
+        start_date: Fecha de inicio (YYYY-MM-DD)
+        end_date: Fecha de fin (YYYY-MM-DD)
+    """
+    try:
+        # Obtener parámetros de consulta
+        start_date = request.args.get('start_date', None)
+        end_date = request.args.get('end_date', None)
+        
+        # Si no se especifica end_date, usar la fecha actual
+        if not end_date:
+            end_date = datetime.now().strftime('%Y-%m-%d')
+            
+        # Si no se especifica start_date, usar el mes actual
+        if not start_date:
+            # Primer día del mes actual
+            current_month = datetime.now().replace(day=1)
+            start_date = current_month.strftime('%Y-%m-%d')
+        
+        # Obtener datos detallados de ganancia por proceso
+        data = get_detailed_profit_by_process(start_date, end_date)
+        
+        return jsonify(data)
+    except Exception as e:
+        logger.error(f"Error al obtener ganancia detallada por proceso: {e}")
+        return jsonify({
+            'error': str(e),
+            'message': 'Error al obtener ganancia detallada por proceso'
         }), 500
 
 @api_bp.route('/raw/compras', methods=['GET'])


### PR DESCRIPTION
## Descripción
Este pull request añade una nueva funcionalidad que permite ver el detalle de las ganancias reales por cada proceso individual de café.

## Cambios principales
- Se ha agregado una nueva función en el backend (`get_detailed_profit_by_process`) que calcula la ganancia real de forma detallada para cada proceso individual.
- Se ha creado un nuevo endpoint en la API (`/proceso-ganancia`) para obtener estos datos.
- Se ha implementado una nueva página en el frontend (`ProcessProfitPage`) que muestra el detalle de ganancias por proceso.
- Se ha añadido un enlace directo desde el dashboard principal hacia la página de detalle.
- Se han creado nuevos componentes de soporte como `DateRangePicker` y `LoadingSpinner`.
- Se ha actualizado la navegación lateral para incluir la nueva sección.

## Cómo probar
1. Iniciar la aplicación en modo desarrollo
2. Navegar al dashboard principal
3. Hacer clic en el card de "Ganancia Real (Por Proceso)" o en la opción "Ganancia por Proceso" del menú lateral
4. Verificar que se muestra correctamente el detalle de ganancias por proceso
5. Probar la funcionalidad de filtrado por fechas

## Screenshots
N/A